### PR TITLE
Make VolOracle more scalable

### DIFF
--- a/contracts/core/OptionsPremiumPricer.sol
+++ b/contracts/core/OptionsPremiumPricer.sol
@@ -14,6 +14,7 @@ contract OptionsPremiumPricer is DSMath {
     /**
      * Immutables
      */
+    address public immutable pool;
     IVolatilityOracle public immutable volatilityOracle;
     IPriceOracle public immutable priceOracle;
     IPriceOracle public immutable stablesOracle;
@@ -21,14 +22,17 @@ contract OptionsPremiumPricer is DSMath {
     // For reference - IKEEP3rVolatility: 0xCCdfCB72753CfD55C5afF5d98eA5f9C43be9659d
 
     constructor(
+        address _pool,
         address _volatilityOracle,
         address _priceOracle,
         address _stablesOracle
     ) {
+        require(_pool != address(0), "!_pool");
         require(_volatilityOracle != address(0), "!_volatilityOracle");
         require(_priceOracle != address(0), "!_priceOracle");
         require(_stablesOracle != address(0), "!_stablesOracle");
 
+        pool = _pool;
         volatilityOracle = IVolatilityOracle(_volatilityOracle);
         priceOracle = IPriceOracle(_priceOracle);
         stablesOracle = IPriceOracle(_stablesOracle);
@@ -227,7 +231,7 @@ contract OptionsPremiumPricer is DSMath {
         );
         // annualized vol * 10 ** 8 because delta expects 18 decimals
         // and annualizedVol is 8 decimals
-        v = volatilityOracle.annualizedVol().mul(10**10);
+        v = volatilityOracle.annualizedVol(pool).mul(10**10);
         t = expiryTimestamp.sub(block.timestamp).div(1 days);
     }
 

--- a/contracts/core/VolOracle.sol
+++ b/contracts/core/VolOracle.sol
@@ -18,7 +18,6 @@ contract VolOracle is DSMath {
      */
     uint32 public immutable period;
     uint256 public immutable annualizationConstant;
-    uint8 private immutable baseCurrencyDecimals;
     uint256 internal constant commitPhaseDuration = 1800; // 30 minutes from every period
 
     /**
@@ -57,34 +56,11 @@ contract VolOracle is DSMath {
 
     /**
      * @notice Creates an volatility oracle for a pool
-     * @param _pool is the Uniswap v3 pool
-     * @param _baseCurrency is the currency to measure the volatility of
-     * @param _quoteCurrency is the currency to quote the volatility in
      * @param _period is how often the oracle needs to be updated
      */
     constructor(uint32 _period) {
-        IUniswapV3Pool uniPool = IUniswapV3Pool(_pool);
-        address token0 = uniPool.token0();
-        address token1 = uniPool.token1();
-
-        require(_pool != address(0), "!_pool");
-        require(_baseCurrency != address(0), "!_baseCurrency");
-        require(_quoteCurrency != address(0), "!_quoteCurrency");
         require(_period > 0, "!_period");
 
-        // Check that the base and quote currencies are part of the pool
-        if (_baseCurrency == token0) {
-            require(_quoteCurrency == token1, "quote needs to be token1");
-        } else if (_baseCurrency == token1) {
-            require(_quoteCurrency == token0, "quote needs to be token0");
-        } else {
-            revert("No matching token");
-        }
-
-        pool = _pool;
-        baseCurrency = _baseCurrency;
-        quoteCurrency = _quoteCurrency;
-        baseCurrencyDecimals = IERC20Detailed(_baseCurrency).decimals();
         period = _period;
 
         // 31536000 seconds in a year
@@ -97,12 +73,12 @@ contract VolOracle is DSMath {
     /**
      * @notice Commits an oracle update
      */
-    function commit() external {
+    function commit(address pool) external {
         (uint32 commitTimestamp, uint32 gapFromPeriod) = secondsFromPeriod();
         require(gapFromPeriod < commitPhaseDuration, "Not commit phase");
 
-        uint256 price = twap();
-        uint256 _lastPrice = lastPrice;
+        uint256 price = twap(pool);
+        uint256 _lastPrice = lastPrices[pool];
         uint256 periodReturn = _lastPrice > 0 ? wdiv(price, _lastPrice) : 0;
 
         // logReturn is in 10**18
@@ -112,7 +88,7 @@ contract VolOracle is DSMath {
                 ? PRBMathSD59x18.ln(int256(periodReturn)) / 10**10
                 : 0;
 
-        Accumulator storage accum = accumulator;
+        Accumulator storage accum = accumulators[pool];
 
         require(
             block.timestamp >=
@@ -131,7 +107,7 @@ contract VolOracle is DSMath {
         accum.mean = uint96(newMean);
         accum.m2 = uint112(newM2);
         accum.lastTimestamp = commitTimestamp;
-        lastPrice = price;
+        lastPrices[pool] = price;
 
         emit Commit(
             uint16(newCount),
@@ -147,17 +123,21 @@ contract VolOracle is DSMath {
      * @notice Returns the standard deviation of the base currency in 10**8 i.e. 1*10**8 = 100%
      * @return standardDeviation is the standard deviation of the asset
      */
-    function vol() public view returns (uint256 standardDeviation) {
-        return Welford.stdev(accumulator.count, accumulator.m2);
+    function vol(address pool) public view returns (uint256 standardDeviation) {
+        return Welford.stdev(accumulators[pool].count, accumulators[pool].m2);
     }
 
     /**
      * @notice Returns the annualized standard deviation of the base currency in 10**8 i.e. 1*10**8 = 100%
      * @return annualStdev is the annualized standard deviation of the asset
      */
-    function annualizedVol() public view returns (uint256 annualStdev) {
+    function annualizedVol(address pool)
+        public
+        view
+        returns (uint256 annualStdev)
+    {
         return
-            Welford.stdev(accumulator.count, accumulator.m2).mul(
+            Welford.stdev(accumulators[pool].count, accumulators[pool].m2).mul(
                 annualizationConstant
             );
     }
@@ -173,6 +153,7 @@ contract VolOracle is DSMath {
             uint32 duration
         ) = getTickCumulatives(pool);
 
+        IUniswapV3Pool uniPool = IUniswapV3Pool(pool);
         address token0 = uniPool.token0();
         address token1 = uniPool.token1();
 
@@ -183,10 +164,9 @@ contract VolOracle is DSMath {
                 duration
             );
 
-        IUniswapV3Pool uniPool = IUniswapV3Pool(pool);
-
         // Get the price of a unit of asset
         // For ETH, it would be 1 ether (10**18)
+        uint256 baseCurrencyDecimals = IERC20Detailed(token0).decimals();
         uint128 quoteAmount = uint128(1 * 10**baseCurrencyDecimals);
 
         return

--- a/contracts/interfaces/IVolatilityOracle.sol
+++ b/contracts/interfaces/IVolatilityOracle.sol
@@ -2,13 +2,17 @@
 pragma solidity ^0.7.3;
 
 interface IVolatilityOracle {
-    function commit() external;
+    function commit(address pool) external;
 
-    function twap() external returns (uint256 price);
+    function twap(address pool) external returns (uint256 price);
 
-    function vol() external view returns (uint256 standardDeviation);
+    function vol(address pool)
+        external
+        view
+        returns (uint256 standardDeviation);
 
-    function annualizedVol() external view returns (uint256 annualStdev);
-
-    function baseCurrency() external view returns (address currency);
+    function annualizedVol(address pool)
+        external
+        view
+        returns (uint256 annualStdev);
 }

--- a/test/core/OptionsPremiumPricer.ts
+++ b/test/core/OptionsPremiumPricer.ts
@@ -24,8 +24,8 @@ describe("OptionsPremiumPricer", () => {
   const WAD = BigNumber.from(10).pow(18);
 
   const ethusdcPool = "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8";
-  const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
-  const usdc = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+  // const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+  // const usdc = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 
   const wethPriceOracleAddress = "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419";
   const usdcPriceOracleAddress = "0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6";

--- a/test/core/OptionsPremiumPricer.ts
+++ b/test/core/OptionsPremiumPricer.ts
@@ -38,8 +38,9 @@ describe("OptionsPremiumPricer", () => {
       signer
     );
 
-    mockOracle = await TestVolOracle.deploy(ethusdcPool, weth, usdc, PERIOD);
+    mockOracle = await TestVolOracle.deploy(PERIOD);
     optionsPremiumPricer = await OptionsPremiumPricer.deploy(
+      ethusdcPool,
       mockOracle.address,
       wethPriceOracleAddress,
       usdcPriceOracleAddress
@@ -446,7 +447,7 @@ describe("OptionsPremiumPricer", () => {
       await mockOracle.setPrice(values[i]);
       const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
       await time.increaseTo(topOfPeriod);
-      await mockOracle.mockCommit();
+      await mockOracle.mockCommit(ethusdcPool);
     }
   };
 });

--- a/test/core/VolOracle.ts
+++ b/test/core/VolOracle.ts
@@ -32,7 +32,10 @@ describe("VolOracle", () => {
 
   describe("twap", () => {
     it("gets the TWAP for a period", async function () {
-      assert.equal((await oracle.twap(ethusdcPool)).toString(), "2427732358");
+      assert.equal(
+        (await oracle.twap(ethusdcPool)).toString(),
+        "411907019541423"
+      );
     });
   });
 
@@ -55,7 +58,7 @@ describe("VolOracle", () => {
       assert.equal(mean1.toNumber(), 0);
       assert.equal(m2_1.toNumber(), 0);
 
-      let stdev = await oracle.vol();
+      let stdev = await oracle.vol(ethusdcPool);
       assert.equal(stdev.toNumber(), 0);
     });
 
@@ -109,14 +112,14 @@ describe("VolOracle", () => {
       // First time is more expensive
       const tx1 = await oracle.commit(ethusdcPool);
       const receipt1 = await tx1.wait();
-      assert.isAtMost(receipt1.gasUsed.toNumber(), 84000);
+      assert.isAtMost(receipt1.gasUsed.toNumber(), 99000);
 
       await time.increaseTo(topOfPeriod + PERIOD);
 
       // Second time is cheaper
       const tx2 = await oracle.commit(ethusdcPool);
       const receipt2 = await tx2.wait();
-      assert.isAtMost(receipt2.gasUsed.toNumber(), 48000);
+      assert.isAtMost(receipt2.gasUsed.toNumber(), 62000);
     });
 
     it("updates the vol", async function () {
@@ -137,7 +140,7 @@ describe("VolOracle", () => {
         await mockOracle.setPrice(values[i]);
         const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
         await time.increaseTo(topOfPeriod);
-        await mockOracle.mockCommit();
+        await mockOracle.mockCommit(ethusdcPool);
         let stdev = await mockOracle.vol(ethusdcPool);
         assert.equal(stdev.toString(), stdevs[i].toString());
       }
@@ -166,7 +169,7 @@ describe("VolOracle", () => {
         await mockOracle.setPrice(values[i]);
         const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
         await time.increaseTo(topOfPeriod);
-        await mockOracle.mockCommit();
+        await mockOracle.mockCommit(ethusdcPool);
       }
       assert.equal((await mockOracle.vol(ethusdcPool)).toString(), "6121243"); // 6.12%
       assert.equal(


### PR DESCRIPTION
Changed VolOracle to do N pools instead of a single pool. This is so that we don't have to deploy new oracle contracts every time a new asset is needed