### PR TITLE
Add negative number support for mean

### DIFF
--- a/contracts/core/VolOracle.sol
+++ b/contracts/core/VolOracle.sol
@@ -32,7 +32,7 @@ contract VolOracle is DSMath {
         // Timestamp of the last record
         uint32 lastTimestamp;
         // Smaller size because prices denominated in USDC, max 7.9e27
-        uint96 mean;
+        int96 mean;
         // Stores the sum of squared errors
         uint112 m2;
     }
@@ -50,7 +50,7 @@ contract VolOracle is DSMath {
     event Commit(
         uint16 count,
         uint32 commitTimestamp,
-        uint96 mean,
+        int96 mean,
         uint112 m2,
         uint256 newValue,
         address committer
@@ -98,15 +98,15 @@ contract VolOracle is DSMath {
             "Committed"
         );
 
-        (uint256 newCount, uint256 newMean, uint256 newM2) =
+        (uint256 newCount, int256 newMean, uint256 newM2) =
             Welford.update(accum.count, accum.mean, accum.m2, logReturn);
 
         require(newCount < type(uint16).max, ">U16");
-        require(newMean < type(uint96).max, ">U96");
+        require(newMean < type(int96).max, ">U96");
         require(newM2 < type(uint112).max, ">U112");
 
         accum.count = uint16(newCount);
-        accum.mean = uint96(newMean);
+        accum.mean = int96(newMean);
         accum.m2 = uint112(newM2);
         accum.lastTimestamp = commitTimestamp;
         lastPrices[pool] = price;
@@ -114,7 +114,7 @@ contract VolOracle is DSMath {
         emit Commit(
             uint16(newCount),
             uint32(commitTimestamp),
-            uint96(newMean),
+            int96(newMean),
             uint112(newM2),
             price,
             msg.sender

--- a/contracts/core/VolOracle.sol
+++ b/contracts/core/VolOracle.sol
@@ -102,7 +102,7 @@ contract VolOracle is DSMath {
             Welford.update(accum.count, accum.mean, accum.m2, logReturn);
 
         require(newCount < type(uint16).max, ">U16");
-        require(newMean < type(int96).max, ">U96");
+        require(newMean < type(int96).max, ">I96");
         require(newM2 < type(uint112).max, ">U112");
 
         accum.count = uint16(newCount);

--- a/contracts/libraries/Welford.sol
+++ b/contracts/libraries/Welford.sol
@@ -23,7 +23,7 @@ library Welford {
         int256 newValue
     )
         internal
-        view
+        pure
         returns (
             uint256 count,
             int256 mean,

--- a/contracts/libraries/Welford.sol
+++ b/contracts/libraries/Welford.sol
@@ -3,7 +3,6 @@ pragma solidity 0.7.3;
 
 import {SignedSafeMath} from "@openzeppelin/contracts/math/SignedSafeMath.sol";
 import {Math} from "./Math.sol";
-import "hardhat/console.sol";
 
 // REFERENCE
 // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm

--- a/contracts/libraries/Welford.sol
+++ b/contracts/libraries/Welford.sol
@@ -3,6 +3,7 @@ pragma solidity 0.7.3;
 
 import {SignedSafeMath} from "@openzeppelin/contracts/math/SignedSafeMath.sol";
 import {Math} from "./Math.sol";
+import "hardhat/console.sol";
 
 // REFERENCE
 // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
@@ -18,15 +19,15 @@ library Welford {
      */
     function update(
         uint256 curCount,
-        uint256 curMean,
+        int256 curMean,
         uint256 curM2,
         int256 newValue
     )
         internal
-        pure
+        view
         returns (
             uint256 count,
-            uint256 mean,
+            int256 mean,
             uint256 m2
         )
     {
@@ -37,11 +38,10 @@ library Welford {
         int256 _m2 = int256(curM2).add(delta.mul(delta2));
 
         require(_count > 0, "count<=0");
-        require(_mean >= 0, "mean<0");
         require(_m2 >= 0, "m2<0");
 
         count = uint256(_count);
-        mean = uint256(_mean);
+        mean = _mean;
         m2 = uint256(_m2);
     }
 

--- a/contracts/tests/TestVolOracle.sol
+++ b/contracts/tests/TestVolOracle.sol
@@ -37,15 +37,15 @@ contract TestVolOracle is DSMath, VolOracle {
             "Committed"
         );
 
-        (uint256 newCount, uint256 newMean, uint256 newM2) =
+        (uint256 newCount, int256 newMean, uint256 newM2) =
             Welford.update(accum.count, accum.mean, accum.m2, logReturn);
 
         require(newCount < type(uint16).max, ">U16");
-        require(newMean < type(uint96).max, ">U96");
+        require(newMean < type(int96).max, ">U96");
         require(newM2 < type(uint112).max, ">U112");
 
         accum.count = uint16(newCount);
-        accum.mean = uint96(newMean);
+        accum.mean = int96(newMean);
         accum.m2 = uint112(newM2);
         accum.lastTimestamp = commitTimestamp;
         lastPrices[pool] = price;
@@ -53,7 +53,7 @@ contract TestVolOracle is DSMath, VolOracle {
         emit Commit(
             uint16(newCount),
             uint32(commitTimestamp),
-            uint96(newMean),
+            int96(newMean),
             uint112(newM2),
             price,
             msg.sender

--- a/contracts/tests/TestWelford.sol
+++ b/contracts/tests/TestWelford.sol
@@ -5,12 +5,12 @@ import {Welford} from "../libraries/Welford.sol";
 
 contract TestWelford {
     uint256 public count;
-    uint256 public mean;
+    int256 public mean;
     uint256 public m2;
 
-    function update(uint256 newValue) external {
-        (uint256 newCount, uint256 newMean, uint256 newM2) =
-            Welford.update(count, mean, m2, int256(newValue));
+    function update(int256 newValue) external {
+        (uint256 newCount, int256 newMean, uint256 newM2) =
+            Welford.update(count, mean, m2, newValue);
 
         count = newCount;
         mean = newMean;

--- a/test/libraries/Welford.ts
+++ b/test/libraries/Welford.ts
@@ -3,6 +3,7 @@ import { assert } from "chai";
 import { Contract } from "@ethersproject/contracts";
 import { BigNumber } from "@ethersproject/bignumber";
 import { parseUnits } from "@ethersproject/units";
+import * as time from "../helpers/time";
 
 const stdev = (values: BigNumber[]) => {
   let sum = BigNumber.from(0);
@@ -31,7 +32,27 @@ describe("Welford", () => {
     testWelford = await TestWelford.deploy();
   });
 
+  describe("update", () => {
+    time.revertToSnapshotAfterEach();
+
+    it("takes in negative values", async function () {
+      await testWelford.update(-100);
+      assert.equal((await testWelford.count()).toString(), "1");
+      assert.equal((await testWelford.mean()).toString(), BigNumber.from(-100));
+      assert.equal((await testWelford.m2()).toString(), BigNumber.from(0));
+
+      await testWelford.update(-200);
+      assert.equal((await testWelford.count()).toString(), "2");
+      assert.equal((await testWelford.mean()).toString(), BigNumber.from(-150));
+      assert.equal((await testWelford.m2()).toString(), BigNumber.from(5000));
+
+      assert.equal((await testWelford.stdev()).toString(), "50");
+    });
+  });
+
   describe("stdev", () => {
+    time.revertToSnapshotAfterEach();
+
     it("matches stdev", async function () {
       let values: BigNumber[] = [];
       const start = 2000;


### PR DESCRIPTION
Oracle updates were failing because we had `require(_mean >= 0, "mean<0")`, which meant that it would revert when the mean is negative.

We remove that constraint entirely and make `mean` a signed integer instead