### PR TITLE
Only Change Test Mnemonic Envar If It's Not Already Defined

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,7 +6,7 @@ import deployOptionsPremiumPricer from "./scripts/deploy-optionspremiumpricer";
 
 require("dotenv").config();
 
-process.env.TEST_MNEMONIC =
+process.env.TEST_MNEMONIC = !!process.env.TEST_MNEMONIC ? process.env.TEST_MNEMONIC : 
   "test test test test test test test test test test test junk";
 
 export default {


### PR DESCRIPTION
If the developer has `TEST_MNEMONIC` already defined in their environment, it gets changed anyway to "test test..." in the hardhat config. This PR has that value change *only* if `TEST_MNEMONIC` isn't already defined.