### PR TITLE
WIP: Avax PoC using getTokenPrice() for pricing

### DIFF
--- a/contracts/tests/TestVolOracle.sol
+++ b/contracts/tests/TestVolOracle.sol
@@ -20,7 +20,7 @@ contract TestVolOracle is DSMath, VolOracle {
         require(observations[pool].length > 0, "!pool initialize");
 
         (uint32 commitTimestamp, uint32 gapFromPeriod) = secondsFromPeriod();
-        require(gapFromPeriod < commitPhaseDuration, "Not commit phase");
+        // require(gapFromPeriod < commitPhaseDuration, "Not commit phase");
 
         uint256 price = mockTwap();
         uint256 _lastPrice = lastPrices[pool];


### PR DESCRIPTION
WIP: AVAX PoC 

Currently pulling the token price from a forked Uniswap v2 pool - compatible with Trader Joes or Pangolin Pairs.

This function needs to be update to use TWAP or Chainlink oracle to prevent price manipulation (e.g. flashloans usage) on illiquid pools.