### PR TITLE
rvol oracle: Adding Chainlink support

### DIFF
--- a/contracts/core/ChainlinkVolOracle.sol
+++ b/contracts/core/ChainlinkVolOracle.sol
@@ -16,8 +16,18 @@ contract ChainlinkVolOracle is VolOracle {
         override
         returns (uint256)
     {
-        (, int256 price, , , ) =
-            AggregatorV3Interface(priceFeed).latestRoundData();
-        return uint256(DSMath.imax(price, 0)); // Avoid negative prices from Chainlink
+        (
+            uint80 roundID,
+            int256 price,
+            ,
+            uint256 timeStamp,
+            uint80 answeredInRound
+        ) = AggregatorV3Interface(priceFeed).latestRoundData();
+
+        require(answeredInRound >= roundID, "Stale oracle price");
+        require(timeStamp != 0, "!timeStamp");
+
+        // Avoid negative prices from Chainlink
+        return uint256(DSMath.imax(price, 0));
     }
 }

--- a/contracts/core/ChainlinkVolOracle.sol
+++ b/contracts/core/ChainlinkVolOracle.sol
@@ -1,0 +1,23 @@
+//SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.7.3;
+
+import "@chainlink/contracts/src/v0.7/interfaces/AggregatorV3Interface.sol";
+import {DSMath} from "../libraries/DSMath.sol";
+import {VolOracle} from "./VolOracle.sol";
+
+contract ChainlinkVolOracle is VolOracle {
+    constructor(uint32 _period, uint256 _windowInDays)
+        VolOracle(_period, _windowInDays)
+    {}
+
+    function getPrice(address priceFeed)
+        public
+        view
+        override
+        returns (uint256)
+    {
+        (, int256 price, , , ) =
+            AggregatorV3Interface(priceFeed).latestRoundData();
+        return uint256(DSMath.imax(price, 0)); // Avoid negative prices from Chainlink
+    }
+}

--- a/contracts/core/V3TwapVolOracle.sol
+++ b/contracts/core/V3TwapVolOracle.sol
@@ -1,0 +1,114 @@
+//SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.7.3;
+
+import {
+    IUniswapV3Pool
+} from "@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol";
+import {VolOracle} from "./VolOracle.sol";
+import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
+import {OracleLibrary} from "../libraries/OracleLibrary.sol";
+import {IERC20Detailed} from "../interfaces/IERC20Detailed.sol";
+
+contract V3TwapVolOracle is VolOracle {
+    using SafeMath for uint256;
+
+    constructor(uint32 _period, uint256 _windowInDays)
+        VolOracle(_period, _windowInDays)
+    {}
+
+    /**
+     * @notice Returns the TWAP for the entire Uniswap observation period
+     * @return price is the TWAP quoted in quote currency
+     */
+    function getPrice(address pool)
+        public
+        view
+        override
+        returns (uint256 price)
+    {
+        (
+            int56 oldestTickCumulative,
+            int56 newestTickCumulative,
+            uint32 duration
+        ) = getTickCumulatives(pool);
+
+        IUniswapV3Pool uniPool = IUniswapV3Pool(pool);
+        address token0 = uniPool.token0();
+        address token1 = uniPool.token1();
+
+        require(duration > 0, "!duration");
+
+        int24 timeWeightedAverageTick =
+            getTimeWeightedAverageTick(
+                oldestTickCumulative,
+                newestTickCumulative,
+                duration
+            );
+
+        // Get the price of a unit of asset
+        // For ETH, it would be 1 ether (10**18)
+        uint256 baseCurrencyDecimals = IERC20Detailed(token0).decimals();
+        uint128 quoteAmount = uint128(1 * 10**baseCurrencyDecimals);
+
+        return
+            OracleLibrary.getQuoteAtTick(
+                timeWeightedAverageTick,
+                quoteAmount,
+                token0,
+                token1
+            );
+    }
+
+    /**
+     * @notice Gets the time weighted average tick
+     * @return timeWeightedAverageTick is the tick which was resolved to be the time-weighted average
+     */
+    function getTimeWeightedAverageTick(
+        int56 olderTickCumulative,
+        int56 newerTickCumulative,
+        uint32 duration
+    ) private pure returns (int24 timeWeightedAverageTick) {
+        int56 tickCumulativesDelta = newerTickCumulative - olderTickCumulative;
+        int24 _timeWeightedAverageTick = int24(tickCumulativesDelta / duration);
+
+        // Always round to negative infinity
+        if (tickCumulativesDelta < 0 && (tickCumulativesDelta % duration != 0))
+            _timeWeightedAverageTick--;
+
+        return _timeWeightedAverageTick;
+    }
+
+    /**
+     * @notice Gets the tick cumulatives which is the tick * seconds
+     * @return oldestTickCumulative is the tick cumulative at last index of the observations array
+     * @return newestTickCumulative is the tick cumulative at the first index of the observations array
+     * @return duration is the TWAP duration determined by the difference between newest-oldest
+     */
+    function getTickCumulatives(address pool)
+        private
+        view
+        returns (
+            int56 oldestTickCumulative,
+            int56 newestTickCumulative,
+            uint32 duration
+        )
+    {
+        IUniswapV3Pool uniPool = IUniswapV3Pool(pool);
+
+        (, , uint16 newestIndex, uint16 observationCardinality, , , ) =
+            uniPool.slot0();
+
+        // Get the latest observation
+        (uint32 newestTimestamp, int56 _newestTickCumulative, , ) =
+            uniPool.observations(newestIndex);
+
+        // Get the oldest observation
+        uint256 oldestIndex = (newestIndex + 1) % observationCardinality;
+        (uint32 oldestTimestamp, int56 _oldestTickCumulative, , ) =
+            uniPool.observations(oldestIndex);
+
+        uint32 _duration = newestTimestamp - oldestTimestamp;
+
+        return (_oldestTickCumulative, _newestTickCumulative, _duration);
+    }
+}

--- a/contracts/interfaces/IVolatilityOracle.sol
+++ b/contracts/interfaces/IVolatilityOracle.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.7.3;
 interface IVolatilityOracle {
     function commit(address pool) external;
 
-    function twap(address pool) external returns (uint256 price);
+    function getPrice(address pool) external view returns (uint256);
 
     function vol(address pool)
         external

--- a/contracts/tests/TestVolOracle.sol
+++ b/contracts/tests/TestVolOracle.sol
@@ -22,7 +22,7 @@ contract TestVolOracle is DSMath, VolOracle {
         (uint32 commitTimestamp, uint32 gapFromPeriod) = secondsFromPeriod();
         require(gapFromPeriod < commitPhaseDuration, "Not commit phase");
 
-        uint256 price = mockTwap();
+        uint256 price = getPrice(pool);
         uint256 _lastPrice = lastPrices[pool];
         uint256 periodReturn = _lastPrice > 0 ? wdiv(price, _lastPrice) : 0;
 
@@ -73,7 +73,7 @@ contract TestVolOracle is DSMath, VolOracle {
         );
     }
 
-    function mockTwap() private view returns (uint256) {
+    function getPrice(address) public view override returns (uint256) {
         return _price;
     }
 

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     ]
   },
   "dependencies": {
+    "@chainlink/contracts": "^0.2.2",
     "@uniswap/v3-core": "^1.0.0",
     "@uniswap/v3-periphery": "^1.0.1",
     "axios": "^0.21.1",

--- a/test/core/OptionsPremiumPricer.ts
+++ b/test/core/OptionsPremiumPricer.ts
@@ -361,8 +361,8 @@ describe("OptionsPremiumPricer", () => {
         true
       );
 
-      assert.isAtMost(callGas.toNumber(), 56561);
-      assert.isAtMost(putGas.toNumber(), 74013);
+      assert.isAtMost(callGas.toNumber(), 56575);
+      assert.isAtMost(putGas.toNumber(), 74027);
       // console.log("getPremium call:", callGas.toNumber());
       // console.log("getPremium put:", putGas.toNumber());
     });

--- a/test/core/VolOracle.ts
+++ b/test/core/VolOracle.ts
@@ -11,7 +11,8 @@ const { provider, getContractFactory } = ethers;
 moment.tz.setDefault("UTC");
 
 describe("VolOracle", () => {
-  let oracle: Contract;
+  let v3TwapOracle: Contract;
+  let chainlinkOracle: Contract;
   let mockOracle: Contract;
   let signer: SignerWithAddress;
 
@@ -19,23 +20,31 @@ describe("VolOracle", () => {
   const WINDOW_IN_DAYS = 7; // weekly vol data
   const COMMIT_PHASE_DURATION = 1800; // 30 mins
   const ethusdcPool = "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8";
+  const ethusdcPriceFeed = "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419";
   // const wbtcusdcPool = "0x99ac8cA7087fA4A2A1FB6357269965A2014ABc35";
 
   before(async function () {
     [signer] = await ethers.getSigners();
-    const VolOracle = await getContractFactory("VolOracle", signer);
+    const V3TwapVolOracle = await getContractFactory("V3TwapVolOracle", signer);
+    const ChainlinkVolOracle = await getContractFactory("ChainlinkVolOracle", signer);
     const TestVolOracle = await getContractFactory("TestVolOracle", signer);
 
-    oracle = await VolOracle.deploy(PERIOD, WINDOW_IN_DAYS);
+    v3TwapOracle = await V3TwapVolOracle.deploy(PERIOD, WINDOW_IN_DAYS);
+    chainlinkOracle = await ChainlinkVolOracle.deploy(PERIOD, WINDOW_IN_DAYS);
     mockOracle = await TestVolOracle.deploy(PERIOD, WINDOW_IN_DAYS);
-    // oracle = await VolOracle.deploy(ethusdcPool, weth, usdc);
   });
 
   describe("twap", () => {
-    it("gets the TWAP for a period", async function () {
+    it("v3TwapVolOracle: gets the TWAP for a period", async function () {
       assert.equal(
-        (await oracle.twap(ethusdcPool)).toString(),
+        (await v3TwapOracle.getPrice(ethusdcPool)).toString(),
         "411907019541423"
+      );
+    });
+    it("chainlinkOracle: gets the price feed for a period", async function () {
+      assert.equal(
+        (await chainlinkOracle.getPrice(ethusdcPriceFeed)).toString(),
+        "241664000000"
       );
     });
   });
@@ -43,116 +52,214 @@ describe("VolOracle", () => {
   describe("initPool", () => {
     time.revertToSnapshotAfterEach();
 
-    it("initializes pool", async function () {
-      await expect(oracle.commit(ethusdcPool)).to.be.revertedWith(
+    it("v3TwapOracle: initializes pool", async function () {
+      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith(
         "!pool initialize"
       );
-      await oracle.initPool(ethusdcPool);
-      oracle.commit(ethusdcPool);
+      await v3TwapOracle.initPool(ethusdcPool);
+      v3TwapOracle.commit(ethusdcPool);
     });
 
-    it("reverts when pool has already been initialized", async function () {
-      await oracle.initPool(ethusdcPool);
-      await expect(oracle.initPool(ethusdcPool)).to.be.revertedWith(
+    it("v3TwapOracle: reverts when pool has already been initialized", async function () {
+      await v3TwapOracle.initPool(ethusdcPool);
+      await expect(v3TwapOracle.initPool(ethusdcPool)).to.be.revertedWith(
         "Pool initialized"
       );
     });
+
+    it("chainlinkOracle: initializes pool", async function () {
+      await expect(chainlinkOracle.commit(ethusdcPriceFeed)).to.be.revertedWith(
+        "!pool initialize"
+      );
+      await chainlinkOracle.initPool(ethusdcPriceFeed);
+      chainlinkOracle.commit(ethusdcPriceFeed);
+    });
+
+    it("chainlinkOracle: reverts when pool has already been initialized", async function () {
+      await chainlinkOracle.initPool(ethusdcPriceFeed);
+      await expect(chainlinkOracle.initPool(ethusdcPriceFeed)).to.be.revertedWith(
+        "Pool initialized"
+      );
+    });
+
   });
 
   describe("commit", () => {
     time.revertToSnapshotAfterEach();
 
-    it("commits the twap", async function () {
-      await oracle.initPool(ethusdcPool);
+    it("v3TwapOracle: commits the twap", async function () {
+      await v3TwapOracle.initPool(ethusdcPool);
       const topOfPeriod = await getTopOfPeriod();
       await time.increaseTo(topOfPeriod);
-      await oracle.commit(ethusdcPool);
+      await v3TwapOracle.commit(ethusdcPool);
 
       const {
         lastTimestamp: timestamp1,
         mean: mean1,
         dsq: dsq1,
-      } = await oracle.accumulators(ethusdcPool);
+      } = await v3TwapOracle.accumulators(ethusdcPool);
       assert.equal(timestamp1, topOfPeriod);
       assert.equal(mean1.toNumber(), 0);
       assert.equal(dsq1.toNumber(), 0);
 
-      let stdev = await oracle.vol(ethusdcPool);
+      let stdev = await v3TwapOracle.vol(ethusdcPool);
       assert.equal(stdev.toNumber(), 0);
     });
 
-    it("reverts when out of commit phase", async function () {
-      await oracle.initPool(ethusdcPool);
+    it("chainlinkOracle: commits the price", async function () {
+      await chainlinkOracle.initPool(ethusdcPriceFeed);
+      const topOfPeriod = await getTopOfPeriod();
+      await time.increaseTo(topOfPeriod);
+      await chainlinkOracle.commit(ethusdcPriceFeed);
+
+      const {
+        lastTimestamp: timestamp1,
+        mean: mean1,
+        dsq: dsq1,
+      } = await chainlinkOracle.accumulators(ethusdcPriceFeed);
+      assert.equal(timestamp1, topOfPeriod);
+      assert.equal(mean1.toNumber(), 0);
+      assert.equal(dsq1.toNumber(), 0);
+
+      let stdev = await chainlinkOracle.vol(ethusdcPriceFeed);
+      assert.equal(stdev.toNumber(), 0);
+    });
+
+    it("v3TwapOracle: reverts when out of commit phase", async function () {
+      await v3TwapOracle.initPool(ethusdcPool);
       const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
 
       await time.increaseTo(topOfPeriod - COMMIT_PHASE_DURATION - 10);
-      await expect(oracle.commit(ethusdcPool)).to.be.revertedWith(
+      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith(
         "Not commit phase"
       );
 
       await time.increaseTo(topOfPeriod + COMMIT_PHASE_DURATION + 10);
-      await expect(oracle.commit(ethusdcPool)).to.be.revertedWith(
+      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith(
         "Not commit phase"
       );
     });
 
-    it("reverts when there is an existing commit for period", async function () {
-      await oracle.initPool(ethusdcPool);
+    it("chainlinkOracle: reverts when out of commit phase", async function () {
+      await chainlinkOracle.initPool(ethusdcPriceFeed);
+      const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
+
+      await time.increaseTo(topOfPeriod - COMMIT_PHASE_DURATION - 10);
+      await expect(chainlinkOracle.commit(ethusdcPriceFeed)).to.be.revertedWith(
+        "Not commit phase"
+      );
+
+      await time.increaseTo(topOfPeriod + COMMIT_PHASE_DURATION + 10);
+      await expect(chainlinkOracle.commit(ethusdcPriceFeed)).to.be.revertedWith(
+        "Not commit phase"
+      );
+    });
+
+    it("v3TwapOracle: reverts when there is an existing commit for period", async function () {
+      await v3TwapOracle.initPool(ethusdcPool);
       const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
       await time.increaseTo(topOfPeriod);
 
-      await oracle.commit(ethusdcPool);
+      await v3TwapOracle.commit(ethusdcPool);
 
       // Cannot commit immediately after
-      await expect(oracle.commit(ethusdcPool)).to.be.revertedWith("Committed");
+      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith("Committed");
 
       // Cannot commit before commit phase begins
       const beforePeriod = topOfPeriod + 100;
       await time.increaseTo(beforePeriod);
-      await expect(oracle.commit(ethusdcPool)).to.be.revertedWith("Committed");
+      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith("Committed");
 
       const nextPeriod = topOfPeriod + PERIOD - COMMIT_PHASE_DURATION;
       await time.increaseTo(nextPeriod);
-      await oracle.commit(ethusdcPool);
+      await v3TwapOracle.commit(ethusdcPool);
     });
 
-    it("reverts when pool has not been initialized", async function () {
+    it("chainlinkOracle: reverts when there is an existing commit for period", async function () {
+      await chainlinkOracle.initPool(ethusdcPriceFeed);
+      const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
+      await time.increaseTo(topOfPeriod);
+
+      await chainlinkOracle.commit(ethusdcPriceFeed);
+
+      // Cannot commit immediately after
+      await expect(chainlinkOracle.commit(ethusdcPriceFeed)).to.be.revertedWith("Committed");
+
+      // Cannot commit before commit phase begins
+      const beforePeriod = topOfPeriod + 100;
+      await time.increaseTo(beforePeriod);
+      await expect(chainlinkOracle.commit(ethusdcPriceFeed)).to.be.revertedWith("Committed");
+
+      const nextPeriod = topOfPeriod + PERIOD - COMMIT_PHASE_DURATION;
+      await time.increaseTo(nextPeriod);
+      await chainlinkOracle.commit(ethusdcPriceFeed);
+    });
+
+    it("v3TwapOracle: reverts when pool has not been initialized", async function () {
       const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
       await time.increaseTo(topOfPeriod);
 
       // Cannot commit immediately after
-      await expect(oracle.commit(ethusdcPool)).to.be.revertedWith(
+      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith(
         "!pool initialize"
       );
     });
 
-    it("commits when within commit phase", async function () {
-      await oracle.initPool(ethusdcPool);
+    it("v3TwapOracle: reverts when pool has not been initialized", async function () {
+      const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
+      await time.increaseTo(topOfPeriod);
+
+      // Cannot commit immediately after
+      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith(
+        "!pool initialize"
+      );
+    });
+
+    it("chainlinkOracle: commits when within commit phase", async function () {
+      await chainlinkOracle.initPool(ethusdcPriceFeed);
       const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
       await time.increaseTo(topOfPeriod - COMMIT_PHASE_DURATION);
-      await oracle.commit(ethusdcPool);
+      await chainlinkOracle.commit(ethusdcPriceFeed);
 
       const nextTopOfPeriod = (await getTopOfPeriod()) + PERIOD;
       await time.increaseTo(nextTopOfPeriod + COMMIT_PHASE_DURATION);
-      await oracle.commit(ethusdcPool);
+      await chainlinkOracle.commit(ethusdcPriceFeed);
     });
 
-    it("fits gas budget", async function () {
-      await oracle.initPool(ethusdcPool);
+    it("v3TwapOracle: fits gas budget", async function () {
+      await v3TwapOracle.initPool(ethusdcPool);
       const latestTimestamp = (await provider.getBlock("latest")).timestamp;
       const topOfPeriod = latestTimestamp - (latestTimestamp % PERIOD);
 
       // First time is more expensive
-      const tx1 = await oracle.commit(ethusdcPool);
+      const tx1 = await v3TwapOracle.commit(ethusdcPool);
       const receipt1 = await tx1.wait();
       assert.isAtMost(receipt1.gasUsed.toNumber(), 156538);
 
       await time.increaseTo(topOfPeriod + PERIOD);
 
       // Second time is cheaper
-      const tx2 = await oracle.commit(ethusdcPool);
+      const tx2 = await v3TwapOracle.commit(ethusdcPool);
       const receipt2 = await tx2.wait();
-      assert.isAtMost(receipt2.gasUsed.toNumber(), 72136);
+      assert.isAtMost(receipt2.gasUsed.toNumber(), 72984);
+    });
+
+    it("chainlinkOracle: fits gas budget", async function () {
+      await chainlinkOracle.initPool(ethusdcPriceFeed);
+      const latestTimestamp = (await provider.getBlock("latest")).timestamp;
+      const topOfPeriod = latestTimestamp - (latestTimestamp % PERIOD);
+
+      // First time is more expensive
+      const tx1 = await chainlinkOracle.commit(ethusdcPriceFeed);
+      const receipt1 = await tx1.wait();
+      assert.isAtMost(receipt1.gasUsed.toNumber(), 156538);
+
+      await time.increaseTo(topOfPeriod + PERIOD);
+
+      // Second time is cheaper
+      const tx2 = await chainlinkOracle.commit(ethusdcPriceFeed);
+      const receipt2 = await tx2.wait();
+      assert.isAtMost(receipt2.gasUsed.toNumber(), 72984);
     });
 
     it("updates the vol", async function () {

--- a/test/core/VolOracle.ts
+++ b/test/core/VolOracle.ts
@@ -19,9 +19,8 @@ describe("VolOracle", () => {
   const PERIOD = 86400 / 2; // 12 hours
   const WINDOW_IN_DAYS = 7; // weekly vol data
   const COMMIT_PHASE_DURATION = 1800; // 30 mins
-  const ethusdcPool = "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8";
-  const ethusdcPriceFeed = "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419";
-  // const wbtcusdcPool = "0x99ac8cA7087fA4A2A1FB6357269965A2014ABc35";
+  const usdcEthPool = "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8";
+  const usdcEthPriceFeed = "0x986b5E1e1755e3C2440e960477f25201B0a8bbD4";
 
   before(async function () {
     [signer] = await ethers.getSigners();
@@ -34,17 +33,17 @@ describe("VolOracle", () => {
     mockOracle = await TestVolOracle.deploy(PERIOD, WINDOW_IN_DAYS);
   });
 
-  describe("twap", () => {
+  describe("getPrice", () => {
     it("v3TwapVolOracle: gets the TWAP for a period", async function () {
       assert.equal(
-        (await v3TwapOracle.getPrice(ethusdcPool)).toString(),
+        (await v3TwapOracle.getPrice(usdcEthPool)).toString(),
         "411907019541423"
       );
     });
     it("chainlinkOracle: gets the price feed for a period", async function () {
       assert.equal(
-        (await chainlinkOracle.getPrice(ethusdcPriceFeed)).toString(),
-        "241664000000"
+        (await chainlinkOracle.getPrice(usdcEthPriceFeed)).toString(),
+        "413530668408711"
       );
     });
   });
@@ -53,31 +52,31 @@ describe("VolOracle", () => {
     time.revertToSnapshotAfterEach();
 
     it("v3TwapOracle: initializes pool", async function () {
-      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith(
+      await expect(v3TwapOracle.commit(usdcEthPool)).to.be.revertedWith(
         "!pool initialize"
       );
-      await v3TwapOracle.initPool(ethusdcPool);
-      v3TwapOracle.commit(ethusdcPool);
+      await v3TwapOracle.initPool(usdcEthPool);
+      v3TwapOracle.commit(usdcEthPool);
     });
 
     it("v3TwapOracle: reverts when pool has already been initialized", async function () {
-      await v3TwapOracle.initPool(ethusdcPool);
-      await expect(v3TwapOracle.initPool(ethusdcPool)).to.be.revertedWith(
+      await v3TwapOracle.initPool(usdcEthPool);
+      await expect(v3TwapOracle.initPool(usdcEthPool)).to.be.revertedWith(
         "Pool initialized"
       );
     });
 
     it("chainlinkOracle: initializes pool", async function () {
-      await expect(chainlinkOracle.commit(ethusdcPriceFeed)).to.be.revertedWith(
+      await expect(chainlinkOracle.commit(usdcEthPriceFeed)).to.be.revertedWith(
         "!pool initialize"
       );
-      await chainlinkOracle.initPool(ethusdcPriceFeed);
-      chainlinkOracle.commit(ethusdcPriceFeed);
+      await chainlinkOracle.initPool(usdcEthPriceFeed);
+      chainlinkOracle.commit(usdcEthPriceFeed);
     });
 
     it("chainlinkOracle: reverts when pool has already been initialized", async function () {
-      await chainlinkOracle.initPool(ethusdcPriceFeed);
-      await expect(chainlinkOracle.initPool(ethusdcPriceFeed)).to.be.revertedWith(
+      await chainlinkOracle.initPool(usdcEthPriceFeed);
+      await expect(chainlinkOracle.initPool(usdcEthPriceFeed)).to.be.revertedWith(
         "Pool initialized"
       );
     });
@@ -88,111 +87,111 @@ describe("VolOracle", () => {
     time.revertToSnapshotAfterEach();
 
     it("v3TwapOracle: commits the twap", async function () {
-      await v3TwapOracle.initPool(ethusdcPool);
+      await v3TwapOracle.initPool(usdcEthPool);
       const topOfPeriod = await getTopOfPeriod();
       await time.increaseTo(topOfPeriod);
-      await v3TwapOracle.commit(ethusdcPool);
+      await v3TwapOracle.commit(usdcEthPool);
 
       const {
         lastTimestamp: timestamp1,
         mean: mean1,
         dsq: dsq1,
-      } = await v3TwapOracle.accumulators(ethusdcPool);
+      } = await v3TwapOracle.accumulators(usdcEthPool);
       assert.equal(timestamp1, topOfPeriod);
       assert.equal(mean1.toNumber(), 0);
       assert.equal(dsq1.toNumber(), 0);
 
-      let stdev = await v3TwapOracle.vol(ethusdcPool);
+      let stdev = await v3TwapOracle.vol(usdcEthPool);
       assert.equal(stdev.toNumber(), 0);
     });
 
     it("chainlinkOracle: commits the price", async function () {
-      await chainlinkOracle.initPool(ethusdcPriceFeed);
+      await chainlinkOracle.initPool(usdcEthPriceFeed);
       const topOfPeriod = await getTopOfPeriod();
       await time.increaseTo(topOfPeriod);
-      await chainlinkOracle.commit(ethusdcPriceFeed);
+      await chainlinkOracle.commit(usdcEthPriceFeed);
 
       const {
         lastTimestamp: timestamp1,
         mean: mean1,
         dsq: dsq1,
-      } = await chainlinkOracle.accumulators(ethusdcPriceFeed);
+      } = await chainlinkOracle.accumulators(usdcEthPriceFeed);
       assert.equal(timestamp1, topOfPeriod);
       assert.equal(mean1.toNumber(), 0);
       assert.equal(dsq1.toNumber(), 0);
 
-      let stdev = await chainlinkOracle.vol(ethusdcPriceFeed);
+      let stdev = await chainlinkOracle.vol(usdcEthPriceFeed);
       assert.equal(stdev.toNumber(), 0);
     });
 
     it("v3TwapOracle: reverts when out of commit phase", async function () {
-      await v3TwapOracle.initPool(ethusdcPool);
+      await v3TwapOracle.initPool(usdcEthPool);
       const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
 
       await time.increaseTo(topOfPeriod - COMMIT_PHASE_DURATION - 10);
-      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith(
+      await expect(v3TwapOracle.commit(usdcEthPool)).to.be.revertedWith(
         "Not commit phase"
       );
 
       await time.increaseTo(topOfPeriod + COMMIT_PHASE_DURATION + 10);
-      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith(
+      await expect(v3TwapOracle.commit(usdcEthPool)).to.be.revertedWith(
         "Not commit phase"
       );
     });
 
     it("chainlinkOracle: reverts when out of commit phase", async function () {
-      await chainlinkOracle.initPool(ethusdcPriceFeed);
+      await chainlinkOracle.initPool(usdcEthPriceFeed);
       const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
 
       await time.increaseTo(topOfPeriod - COMMIT_PHASE_DURATION - 10);
-      await expect(chainlinkOracle.commit(ethusdcPriceFeed)).to.be.revertedWith(
+      await expect(chainlinkOracle.commit(usdcEthPriceFeed)).to.be.revertedWith(
         "Not commit phase"
       );
 
       await time.increaseTo(topOfPeriod + COMMIT_PHASE_DURATION + 10);
-      await expect(chainlinkOracle.commit(ethusdcPriceFeed)).to.be.revertedWith(
+      await expect(chainlinkOracle.commit(usdcEthPriceFeed)).to.be.revertedWith(
         "Not commit phase"
       );
     });
 
     it("v3TwapOracle: reverts when there is an existing commit for period", async function () {
-      await v3TwapOracle.initPool(ethusdcPool);
+      await v3TwapOracle.initPool(usdcEthPool);
       const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
       await time.increaseTo(topOfPeriod);
 
-      await v3TwapOracle.commit(ethusdcPool);
+      await v3TwapOracle.commit(usdcEthPool);
 
       // Cannot commit immediately after
-      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith("Committed");
+      await expect(v3TwapOracle.commit(usdcEthPool)).to.be.revertedWith("Committed");
 
       // Cannot commit before commit phase begins
       const beforePeriod = topOfPeriod + 100;
       await time.increaseTo(beforePeriod);
-      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith("Committed");
+      await expect(v3TwapOracle.commit(usdcEthPool)).to.be.revertedWith("Committed");
 
       const nextPeriod = topOfPeriod + PERIOD - COMMIT_PHASE_DURATION;
       await time.increaseTo(nextPeriod);
-      await v3TwapOracle.commit(ethusdcPool);
+      await v3TwapOracle.commit(usdcEthPool);
     });
 
     it("chainlinkOracle: reverts when there is an existing commit for period", async function () {
-      await chainlinkOracle.initPool(ethusdcPriceFeed);
+      await chainlinkOracle.initPool(usdcEthPriceFeed);
       const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
       await time.increaseTo(topOfPeriod);
 
-      await chainlinkOracle.commit(ethusdcPriceFeed);
+      await chainlinkOracle.commit(usdcEthPriceFeed);
 
       // Cannot commit immediately after
-      await expect(chainlinkOracle.commit(ethusdcPriceFeed)).to.be.revertedWith("Committed");
+      await expect(chainlinkOracle.commit(usdcEthPriceFeed)).to.be.revertedWith("Committed");
 
       // Cannot commit before commit phase begins
       const beforePeriod = topOfPeriod + 100;
       await time.increaseTo(beforePeriod);
-      await expect(chainlinkOracle.commit(ethusdcPriceFeed)).to.be.revertedWith("Committed");
+      await expect(chainlinkOracle.commit(usdcEthPriceFeed)).to.be.revertedWith("Committed");
 
       const nextPeriod = topOfPeriod + PERIOD - COMMIT_PHASE_DURATION;
       await time.increaseTo(nextPeriod);
-      await chainlinkOracle.commit(ethusdcPriceFeed);
+      await chainlinkOracle.commit(usdcEthPriceFeed);
     });
 
     it("v3TwapOracle: reverts when pool has not been initialized", async function () {
@@ -200,7 +199,7 @@ describe("VolOracle", () => {
       await time.increaseTo(topOfPeriod);
 
       // Cannot commit immediately after
-      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith(
+      await expect(v3TwapOracle.commit(usdcEthPool)).to.be.revertedWith(
         "!pool initialize"
       );
     });
@@ -210,56 +209,56 @@ describe("VolOracle", () => {
       await time.increaseTo(topOfPeriod);
 
       // Cannot commit immediately after
-      await expect(v3TwapOracle.commit(ethusdcPool)).to.be.revertedWith(
+      await expect(v3TwapOracle.commit(usdcEthPool)).to.be.revertedWith(
         "!pool initialize"
       );
     });
 
     it("chainlinkOracle: commits when within commit phase", async function () {
-      await chainlinkOracle.initPool(ethusdcPriceFeed);
+      await chainlinkOracle.initPool(usdcEthPriceFeed);
       const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
       await time.increaseTo(topOfPeriod - COMMIT_PHASE_DURATION);
-      await chainlinkOracle.commit(ethusdcPriceFeed);
+      await chainlinkOracle.commit(usdcEthPriceFeed);
 
       const nextTopOfPeriod = (await getTopOfPeriod()) + PERIOD;
       await time.increaseTo(nextTopOfPeriod + COMMIT_PHASE_DURATION);
-      await chainlinkOracle.commit(ethusdcPriceFeed);
+      await chainlinkOracle.commit(usdcEthPriceFeed);
     });
 
     it("v3TwapOracle: fits gas budget", async function () {
-      await v3TwapOracle.initPool(ethusdcPool);
+      await v3TwapOracle.initPool(usdcEthPool);
       const latestTimestamp = (await provider.getBlock("latest")).timestamp;
       const topOfPeriod = latestTimestamp - (latestTimestamp % PERIOD);
 
       // First time is more expensive
-      const tx1 = await v3TwapOracle.commit(ethusdcPool);
+      const tx1 = await v3TwapOracle.commit(usdcEthPool);
       const receipt1 = await tx1.wait();
       assert.isAtMost(receipt1.gasUsed.toNumber(), 156538);
 
       await time.increaseTo(topOfPeriod + PERIOD);
 
       // Second time is cheaper
-      const tx2 = await v3TwapOracle.commit(ethusdcPool);
+      const tx2 = await v3TwapOracle.commit(usdcEthPool);
       const receipt2 = await tx2.wait();
       assert.isAtMost(receipt2.gasUsed.toNumber(), 72984);
     });
 
     it("chainlinkOracle: fits gas budget", async function () {
-      await chainlinkOracle.initPool(ethusdcPriceFeed);
+      await chainlinkOracle.initPool(usdcEthPriceFeed);
       const latestTimestamp = (await provider.getBlock("latest")).timestamp;
       const topOfPeriod = latestTimestamp - (latestTimestamp % PERIOD);
 
       // First time is more expensive
-      const tx1 = await chainlinkOracle.commit(ethusdcPriceFeed);
+      const tx1 = await chainlinkOracle.commit(usdcEthPriceFeed);
       const receipt1 = await tx1.wait();
-      assert.isAtMost(receipt1.gasUsed.toNumber(), 156538);
+      assert.isAtMost(receipt1.gasUsed.toNumber(), 96238);
 
       await time.increaseTo(topOfPeriod + PERIOD);
 
       // Second time is cheaper
-      const tx2 = await chainlinkOracle.commit(ethusdcPriceFeed);
+      const tx2 = await chainlinkOracle.commit(usdcEthPriceFeed);
       const receipt2 = await tx2.wait();
-      assert.isAtMost(receipt2.gasUsed.toNumber(), 72984);
+      assert.isAtMost(receipt2.gasUsed.toNumber(), 60911);
     });
 
     it("updates the vol", async function () {
@@ -276,14 +275,14 @@ describe("VolOracle", () => {
         BigNumber.from("3068199"),
       ];
 
-      await mockOracle.initPool(ethusdcPool);
+      await mockOracle.initPool(usdcEthPool);
 
       for (let i = 0; i < values.length; i++) {
         await mockOracle.setPrice(values[i]);
         const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
         await time.increaseTo(topOfPeriod);
-        await mockOracle.mockCommit(ethusdcPool);
-        let stdev = await mockOracle.vol(ethusdcPool);
+        await mockOracle.mockCommit(usdcEthPool);
+        let stdev = await mockOracle.vol(usdcEthPool);
         assert.equal(stdev.toString(), stdevs[i].toString());
       }
     });
@@ -310,17 +309,17 @@ describe("VolOracle", () => {
         BigNumber.from("2650000000"),
       ];
 
-      await mockOracle.initPool(ethusdcPool);
+      await mockOracle.initPool(usdcEthPool);
 
       for (let i = 0; i < values.length; i++) {
         await mockOracle.setPrice(values[i]);
         const topOfPeriod = (await getTopOfPeriod()) + PERIOD;
         await time.increaseTo(topOfPeriod);
-        await mockOracle.mockCommit(ethusdcPool);
+        await mockOracle.mockCommit(usdcEthPool);
       }
-      assert.equal((await mockOracle.vol(ethusdcPool)).toString(), "6607827"); // 6.6%
+      assert.equal((await mockOracle.vol(usdcEthPool)).toString(), "6607827"); // 6.6%
       assert.equal(
-        (await mockOracle.annualizedVol(ethusdcPool)).toString(),
+        (await mockOracle.annualizedVol(usdcEthPool)).toString(),
         "178411329"
       ); // 178% annually
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,11 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@chainlink/contracts@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@chainlink/contracts/-/contracts-0.2.2.tgz#8ea2079d8b22d25807fc63b98ccd3dc0bc2a33fe"
+  integrity sha512-wxXPbt7O3aZaUSG34ufFASC5amRSL6eeYCqsa+2gpqbB8Hk7B7FydEDCI5dqvAC444TlFskPHcVbizCZkRHPpw==
+
 "@ensdomains/ens@^0.4.4":
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/@ensdomains/ens/-/ens-0.4.5.tgz#e0aebc005afdc066447c6e22feb4eda89a5edbfc"


### PR DESCRIPTION
- Adding Chainlink support to the oracle
- Separating oracle contracts out via inheritance.  `V3TwapVolOracle.sol` and `ChainlinkVolOracle.sol`
- Flipped variable names for ETH/USDC to USDC/ETH because we are quoted in ETH and not USDC in the testcases.