### PR TITLE
Use bytes32 as key for ManualVolOracle

### DIFF
--- a/contracts/core/ManualVolOracle.sol
+++ b/contracts/core/ManualVolOracle.sol
@@ -86,7 +86,7 @@ contract ManualVolOracle is AccessControl {
 
     /**
      * @notice Computes the option id for a given Option struct
-     * @param delta is the option's delta, in units of 10**8. E.g. 105% = 1.05 * 10**8
+     * @param delta is the option's delta, in units of 10**4. E.g. 0.1d = 0.1 * 10**4
      * @param underlying is the underlying of the option
      * @param collateralAsset is the collateral used to collateralize the option
      * @param isPut is the flag used to determine if an option is a put or call

--- a/contracts/core/ManualVolOracle.sol
+++ b/contracts/core/ManualVolOracle.sol
@@ -1,4 +1,5 @@
 //SPDX-License-Identifier: GPL-3.0
+pragma experimental ABIEncoderV2;
 pragma solidity 0.7.3;
 
 import "@openzeppelin/contracts/access/AccessControl.sol";
@@ -7,7 +8,20 @@ contract ManualVolOracle is AccessControl {
     /// @dev The identifier of the role which maintains other roles.
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN");
 
-    mapping(address => uint256) private annualizedVols;
+    /// @dev Map of instrument id to IV
+    mapping(bytes32 => uint256) private annualizedVols;
+
+    /**
+     * Instrument describe an option with a specific delta, asset and its option type.
+     */
+    struct Instrument {
+        // option delta
+        uint256 delta;
+        // ERC20 token
+        address asset;
+        // If an otoken is a put or not
+        bool isPut;
+    }
 
     /**
      * @notice Creates an volatility oracle for a pool
@@ -31,7 +45,7 @@ contract ManualVolOracle is AccessControl {
      * @notice Returns the standard deviation of the base currency in 10**8 i.e. 1*10**8 = 100%
      * @return standardDeviation is the standard deviation of the asset
      */
-    function vol(address) public pure returns (uint256 standardDeviation) {
+    function vol(bytes32) public pure returns (uint256 standardDeviation) {
         return 0;
     }
 
@@ -39,36 +53,55 @@ contract ManualVolOracle is AccessControl {
      * @notice Returns the annualized standard deviation of the base currency in 10**8 i.e. 1*10**8 = 100%
      * @return annualStdev is the annualized standard deviation of the asset
      */
-    function annualizedVol(address pool)
+    function annualizedVol(bytes32 instrumentId)
         public
         view
         returns (uint256 annualStdev)
     {
-        return annualizedVols[pool];
+        return annualizedVols[instrumentId];
+    }
+
+    /**
+     * @notice Computes the instrument id for a given Instrument struct
+     * @param instrument is an Instrument struct to encode
+     */
+    function getInstrumentId(Instrument calldata instrument)
+        external
+        pure
+        returns (bytes32)
+    {
+        return
+            keccak256(
+                abi.encodePacked(
+                    instrument.delta,
+                    instrument.asset,
+                    instrument.isPut
+                )
+            );
     }
 
     /**
      * @notice Sets the annualized standard deviation of the base currency of one or more `pool(s)`
-     * @param _pools is an array of uniswap pools we want to set annualized volatility for
+     * @param _instrumentIds is an array of Instrument IDs encoded and hashed with instrumentId
      * @param _newAnnualizedVols is an array of the annualized volatility with 10**8 decimals i.e. 1*10**8 = 100%
      */
     function setAnnualizedVol(
-        address[] calldata _pools,
+        bytes32[] calldata _instrumentIds,
         uint256[] calldata _newAnnualizedVols
     ) external onlyAdmin {
         require(
-            _pools.length == _newAnnualizedVols.length,
+            _instrumentIds.length == _newAnnualizedVols.length,
             "Input lengths mismatched"
         );
 
-        for (uint256 i = 0; i < _pools.length; i++) {
-            address pool = _pools[i];
+        for (uint256 i = 0; i < _instrumentIds.length; i++) {
+            bytes32 instrumentId = _instrumentIds[i];
             uint256 newAnnualizedVol = _newAnnualizedVols[i];
 
             require(newAnnualizedVol > 50 * 10**6, "Cannot be less than 50%");
             require(newAnnualizedVol < 400 * 10**6, "Cannot be more than 400%");
 
-            annualizedVols[pool] = newAnnualizedVol;
+            annualizedVols[instrumentId] = newAnnualizedVol;
         }
     }
 }

--- a/test/core/ManualVolOracle.ts
+++ b/test/core/ManualVolOracle.ts
@@ -5,6 +5,7 @@ import moment from "moment-timezone";
 import * as time from "../helpers/time";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { BigNumber } from "@ethersproject/bignumber";
+import { parseUnits } from "ethers/lib/utils";
 
 const { getContractFactory } = ethers;
 
@@ -15,19 +16,25 @@ describe("ManualVolOracle", () => {
   let signer: SignerWithAddress;
   let signer2: SignerWithAddress;
 
-  const ethusdcPool = "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8";
-  const wbtcusdcPool = "0x99ac8ca7087fa4a2a1fb6357269965a2014abc35";
+  const delta = 1000;
+  const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+  const wbtc = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599";
+  let wethOption: string;
+  let wbtcOption: string;
 
   before(async function () {
     [signer, signer2] = await ethers.getSigners();
     const ManualVolOracle = await getContractFactory("ManualVolOracle", signer);
 
     oracle = await ManualVolOracle.deploy(signer.address);
+
+    wethOption = await oracle.getOptionId(delta, weth, weth, false);
+    wbtcOption = await oracle.getOptionId(delta, wbtc, wbtc, false);
   });
 
   describe("vol", () => {
     it("returns 0 for vol()", async function () {
-      assert.equal((await oracle.vol(ethusdcPool)).toString(), "0");
+      assert.equal((await oracle.vol(wethOption)).toString(), "0");
     });
   });
 
@@ -37,21 +44,21 @@ describe("ManualVolOracle", () => {
     it("reverts when caller not admin", async function () {
       let annualizedVol = 1;
       await expect(
-        oracle.connect(signer2).setAnnualizedVol([ethusdcPool], [annualizedVol])
+        oracle.connect(signer2).setAnnualizedVol([wethOption], [annualizedVol])
       ).to.be.revertedWith("!admin");
     });
 
     it("reverts when passing 0 as annualized vol", async function () {
       let annualizedVol = 0;
       await expect(
-        oracle.setAnnualizedVol([ethusdcPool], [annualizedVol])
+        oracle.setAnnualizedVol([wethOption], [annualizedVol])
       ).to.be.revertedWith("Cannot be less than 50%");
     });
 
     it("reverts when passing <50% as annualized vol", async function () {
       await expect(
         oracle.setAnnualizedVol(
-          [ethusdcPool],
+          [wethOption],
           [BigNumber.from(50).mul(BigNumber.from(10).pow(6))]
         )
       ).to.be.revertedWith("Cannot be less than 50%");
@@ -60,7 +67,7 @@ describe("ManualVolOracle", () => {
     it("reverts when passing >400% as annualized vol", async function () {
       await expect(
         oracle.setAnnualizedVol(
-          [ethusdcPool],
+          [wethOption],
           [BigNumber.from(400).mul(BigNumber.from(10).pow(6))]
         )
       ).to.be.revertedWith("Cannot be more than 400%");
@@ -69,17 +76,15 @@ describe("ManualVolOracle", () => {
     it("reverts when pool array length and annualized vol length mismatch", async function () {
       let ethAnnualizedVol = BigNumber.from(10).pow(8);
       await expect(
-        oracle.setAnnualizedVol(
-          [ethusdcPool, wbtcusdcPool],
-          [ethAnnualizedVol])
+        oracle.setAnnualizedVol([wethOption, wbtcOption], [ethAnnualizedVol])
       ).to.be.revertedWith("Input lengths mismatched");
     });
 
     it("sets the annualized vol for the pool", async function () {
       let annualizedVol = BigNumber.from(10).pow(8);
-      await oracle.setAnnualizedVol([ethusdcPool], [annualizedVol]);
+      await oracle.setAnnualizedVol([wethOption], [annualizedVol]);
       assert.equal(
-        (await oracle.annualizedVol(ethusdcPool)).toString(),
+        (await oracle["annualizedVol(bytes32)"](wethOption)).toString(),
         annualizedVol.toString()
       );
     });
@@ -87,20 +92,23 @@ describe("ManualVolOracle", () => {
     it("sets the annualized vol for multiple pools", async function () {
       let ethAnnualizedVol = BigNumber.from(10).pow(8);
       let wbtcAnnualizedVol = BigNumber.from(10).pow(8).mul(2);
-      await oracle.setAnnualizedVol([ethusdcPool, wbtcusdcPool], [ethAnnualizedVol, wbtcAnnualizedVol]);
+      await oracle.setAnnualizedVol(
+        [wethOption, wbtcOption],
+        [ethAnnualizedVol, wbtcAnnualizedVol]
+      );
       assert.equal(
-        (await oracle.annualizedVol(ethusdcPool)).toString(),
+        (await oracle["annualizedVol(bytes32)"](wethOption)).toString(),
         ethAnnualizedVol.toString()
       );
       assert.equal(
-        (await oracle.annualizedVol(wbtcusdcPool)).toString(),
+        (await oracle["annualizedVol(bytes32)"](wbtcOption)).toString(),
         wbtcAnnualizedVol.toString()
       );
     });
 
     it("fits gas budget (single) [ @skip-on-coverage ]", async function () {
       let annualizedVol = BigNumber.from(10).pow(8);
-      const tx = await oracle.setAnnualizedVol([ethusdcPool], [annualizedVol]);
+      const tx = await oracle.setAnnualizedVol([wethOption], [annualizedVol]);
       const receipt = await tx.wait();
       // console.log(receipt.gasUsed.toNumber());
       assert.isAtMost(receipt.gasUsed.toNumber(), 48000);
@@ -110,10 +118,53 @@ describe("ManualVolOracle", () => {
       let ethAnnualizedVol = BigNumber.from(10).pow(8);
       let wbtcAnnualizedVol = BigNumber.from(10).pow(8).mul(2);
 
-      const tx = await oracle.setAnnualizedVol([ethusdcPool, wbtcusdcPool], [ethAnnualizedVol, wbtcAnnualizedVol]);
+      const tx = await oracle.setAnnualizedVol(
+        [wethOption, wbtcOption],
+        [ethAnnualizedVol, wbtcAnnualizedVol]
+      );
       const receipt = await tx.wait();
       // console.log(receipt.gasUsed.toNumber());
       assert.isAtMost(receipt.gasUsed.toNumber(), 71000);
+    });
+  });
+
+  describe("annualizedVol", () => {
+    time.revertToSnapshotAfterEach();
+
+    const annualizedVol = parseUnits("1", 8);
+
+    before(async () => {
+      await oracle.setAnnualizedVol([wethOption], [annualizedVol]);
+    });
+
+    it("reads the vol after setting", async () => {
+      assert.equal(
+        (await oracle["annualizedVol(bytes32)"](wethOption)).toString(),
+        annualizedVol.toString()
+      );
+    });
+
+    it("reads the vol with unencoded option parameters", async () => {
+      assert.equal(
+        (
+          await oracle["annualizedVol(uint256,address,address,bool)"](
+            delta,
+            weth,
+            weth,
+            false
+          )
+        ).toString(),
+        annualizedVol.toString()
+      );
+    });
+  });
+
+  describe("getOptionId", () => {
+    it("encodes the option id correctly", async () => {
+      assert.equal(
+        await oracle.getOptionId(delta, weth, weth, false),
+        "0x0918a549fd71883e904c96e5ca3e87cb2638815cae382651e3b7d213163455d7"
+      );
     });
   });
 
@@ -128,7 +179,7 @@ describe("ManualVolOracle", () => {
       const annualizedVol = BigNumber.from(10).pow(8);
       await oracle
         .connect(signer2)
-        .setAnnualizedVol([ethusdcPool], [annualizedVol]);
+        .setAnnualizedVol([wethOption], [annualizedVol]);
     });
 
     it("is able to grant default admin role", async () => {


### PR DESCRIPTION
We have operational issues around how we handle ETH calls/puts and how we set their IVs. Normally we have to reset the IV for the ETH options successively (ie ETH call first then ETH puts). To fix this, we separate out the options with:

- asset: ERC20token
- delta: Delta of the option, this is so that we can expand to more aggressive delta options in the future
- isPut: To differentiate between call and put because IVs are affected by the option skew