### PR TITLE
fix: pass possibly negative number to Math.ncdf

### DIFF
--- a/contracts/core/OptionsPremiumPricerInETH.sol
+++ b/contracts/core/OptionsPremiumPricerInETH.sol
@@ -240,7 +240,7 @@ contract OptionsPremiumPricerInETH is DSMath {
             (d1, d2) = derivatives(t, v, st, sp);
             delta = uint256(10)
                 .mul(10**13)
-                .sub(Math.ncdf((Math.FIXED_1 * d2) / 1e18))
+                .sub(Math.cdf(int256(Math.FIXED_1) * int256(d2) / 1e18))
                 .div(10**10);
         }
     }

--- a/contracts/core/OptionsPremiumPricerInStables.sol
+++ b/contracts/core/OptionsPremiumPricerInStables.sol
@@ -233,7 +233,7 @@ contract OptionsPremiumPricerInStables is DSMath {
             (d1, d2) = derivatives(t, v, st, sp);
             delta = uint256(10)
                 .mul(10**13)
-                .sub(Math.ncdf((Math.FIXED_1 * d2) / 1e18))
+                .sub(Math.cdf(int256(Math.FIXED_1) * int256(d2) / 1e18))
                 .div(10**10);
         }
     }


### PR DESCRIPTION
https://github.com/ribbon-finance/rvol/blob/ee066ee4b612bb3c647b14cc48983045ec475f8c/contracts/core/OptionsPremiumPricerInETH.sol#L243
https://github.com/ribbon-finance/rvol/blob/ee066ee4b612bb3c647b14cc48983045ec475f8c/contracts/core/OptionsPremiumPricerInStables.sol#L236

`d2` returned by `derivatives` is possibly negative and should not be passed to `Math.ncdf`