### PR TITLE
fix: input range of current Math.cdf implementation

### DIFF
--- a/contracts/libraries/Math.sol
+++ b/contracts/libraries/Math.sol
@@ -80,7 +80,7 @@ library Math {
             xAux >>= 4;
             result <<= 2;
         }
-        if (xAux >= 0x8) {
+        if (xAux >= 0x4) {
             result <<= 1;
         }
 
@@ -243,10 +243,13 @@ library Math {
     }
 
     function ncdf(uint256 x) internal pure returns (uint256) {
+        if (x > (5656854 * FIXED_1) / 1e6) {
+            return 1e14;
+        }
         int256 t1 = int256(1e7 + ((2316419 * x) / FIXED_1));
-        uint256 exp = ((x / 2) * x) / FIXED_1;
-        int256 d = int256((3989423 * FIXED_1) / optimalExp(uint256(exp)));
-        uint256 prob =
+        uint256 exp = (x * (x >> 3)) / (FIXED_1 >> 2);
+        int256 d = int256((3989423 * FIXED_1) / optimalExp(exp));
+        uint256 prob = 1e14 -
             uint256(
                 (d *
                     (3193815 +
@@ -258,27 +261,13 @@ library Math {
                         t1) *
                     1e7) / t1
             );
-        if (x > 0) prob = 1e14 - prob;
         return prob;
     }
 
     function cdf(int256 x) internal pure returns (uint256) {
-        int256 t1 = int256(1e7 + int256((2316419 * abs(x)) / FIXED_1));
-        uint256 exp = uint256((x / 2) * x) / FIXED_1;
-        int256 d = int256((3989423 * FIXED_1) / optimalExp(uint256(exp)));
-        uint256 prob =
-            uint256(
-                (d *
-                    (3193815 +
-                        ((-3565638 +
-                            ((17814780 +
-                                ((-18212560 + (13302740 * 1e7) / t1) * 1e7) /
-                                t1) * 1e7) /
-                            t1) * 1e7) /
-                        t1) *
-                    1e7) / t1
-            );
-        if (x > 0) prob = 1e14 - prob;
-        return prob;
+        if (x >= 0) {
+            return ncdf(uint256(x));
+        }
+        return 1e14 - ncdf(uint256(-x));
     }
 }


### PR DESCRIPTION
### Summary
With the current implementation of `cdf` and `ncdf`, the input range with correct output is a bit small due to overflows and the algorithm to calculate exponentials in `optimalExp`. This pull request fixes the problems and the modified `cdf` will return good results for all possible inputs with reasonable precision.

### Problem
https://github.com/ribbon-finance/rvol/blob/ee066ee4b612bb3c647b14cc48983045ec475f8c/contracts/libraries/Math.sol#L247
In Math.sol L247 and L267, the calculation of variable `exp` overflows when $$\log_2{\frac{x^2}{2}}\geq256$$ i.e. $$x\geq2^{128.5}$$ considering the variable `x` is 127-bit binary fixed-point, the actual range is $$x\geq2^{128.5}\div2^{127}=2^{1.5}\approx2.8284$$
which means the function can only return correct results for `x < 2.82`, approximately:
<img src="https://user-images.githubusercontent.com/115976846/196146226-46ffbcb5-b357-4b89-bd72-dbd76832b8b0.png" width="300" height="300" />

In rvol we normally pass the Black-Scholes parameters `d1` and `d2` to the CDF functions. They are calculated from spot price, strike, volatility and time to expire of the option or underlying asset. With a reasonable set of these parameters
- spot price is 1.65x of strike
- annualized volatility is 108%
- 7 days left to expire

we get `d1` = 3.408 approximately, which is far larger than the 2.82 limit. So `cdf` can give wrong answers sometimes in options-related contexts.

### Solution
First we replace the `uint256 exp = ((x / 2) * x) / FIXED_1;` line
with `uint256 exp = (x * (x >> 3)) / (FIXED_1 >> 2);`
The 3-bit shift is enough to prevent overflow for $$x\lt\sqrt{32}\approx5.6568542$$ (will explain it later)

After this modification the output of `cdf` is like
<img src="https://user-images.githubusercontent.com/115976846/196156580-3bd9771b-cbc1-4f61-ad54-c81a65f93d80.png" width="300" height="300" />
Now the input range extends to ~5 and it's enough for real options calculations. But we go a step further to make the CDF functions better.
https://github.com/ribbon-finance/rvol/blob/ee066ee4b612bb3c647b14cc48983045ec475f8c/contracts/libraries/Math.sol#L181
This time the periodic falls are due to the algorithm to implement `optimalExp`. After get Taylor series of small residuals it elaborates the exponential for x bit by bit but only to the 131st bit, which corresbonds to the 2^3 bit - so `optimalExp` will return periodic results with 16 as the period (in fixed-point).

Since the argument we pass to `optimalExp` is $\frac{x^2}{2}$, the output falls at $$\frac{x^2}{2}=16\cdot n\quad(n=1,2,3,\ldots)$$
thus the first falling point $$x_1=\sqrt{32}$$
the actual CDF value (0.9999999...) has been very close to 1 since long before this point so we let the functions return 1 if input is greater than it (5.656854)
```
if (x > (5656854 * FIXED_1) / 1e6) {
    return 1e14;
}
```
from previous discussions we know the input `exp` will not overflow either within this range so `cdf` can return good results now:
<img src="https://user-images.githubusercontent.com/115976846/196162609-cbf41656-8253-4c02-b629-e17a218b536d.png" width="300" height="300" />

### One more thing
https://github.com/ribbon-finance/rvol/blob/ee066ee4b612bb3c647b14cc48983045ec475f8c/contracts/libraries/Math.sol#L83
the constant in L83 in `sqrt` should be `0x4` for the last bit in the guess of initial value.